### PR TITLE
Use relative paths to Blockly library files

### DIFF
--- a/demos/Drone/drone.html
+++ b/demos/Drone/drone.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>Blockly Development Environment for AR.Drone</title>
-  <script type="text/javascript" src="/Users/beth/blockly/blockly_compressed.js"></script>
-  <script type="text/javascript" src="/Users/beth/blockly/blocks_compressed.js"></script>
-  <script type="text/javascript" src="/Users/beth/blockly/javascript_compressed.js"></script>
-  <script type="text/javascript" src="/Users/beth/blockly/msg/js/en.js"></script>
-  <script type="text/javascript" src="/Users/beth/blockly/demos/Drone/drone_blocks.js"></script>
-  <script type="text/javascript" src="/Users/beth/blockly/demos/Drone/drone.js"></script>
+  <script type="text/javascript" src="../../blockly_compressed.js"></script>
+  <script type="text/javascript" src="../../blocks_compressed.js"></script>
+  <script type="text/javascript" src="../../javascript_compressed.js"></script>
+  <script type="text/javascript" src="../../msg/js/en.js"></script>
+  <script type="text/javascript" src="../../demos/Drone/drone_blocks.js"></script>
+  <script type="text/javascript" src="../../demos/Drone/drone.js"></script>
   <style>
     body {
       background-color: #fff;

--- a/demos/Drone/drone.html
+++ b/demos/Drone/drone.html
@@ -7,8 +7,8 @@
   <script type="text/javascript" src="../../blocks_compressed.js"></script>
   <script type="text/javascript" src="../../javascript_compressed.js"></script>
   <script type="text/javascript" src="../../msg/js/en.js"></script>
-  <script type="text/javascript" src="../../demos/Drone/drone_blocks.js"></script>
-  <script type="text/javascript" src="../../demos/Drone/drone.js"></script>
+  <script type="text/javascript" src="drone_blocks.js"></script>
+  <script type="text/javascript" src="drone.js"></script>
   <style>
     body {
       background-color: #fff;


### PR DESCRIPTION
Using relative paths instead of absolute paths allows the user to place
the code in any location, rather than it is placed in
/Users/beth/blockly.
